### PR TITLE
Correct typo and add species to data frame when percent_coverage < 90

### DIFF
--- a/parse_mykrobe_predict.py
+++ b/parse_mykrobe_predict.py
@@ -226,7 +226,7 @@ def extract_lineage_info(lineage_data, genome_name, lineage_name_dict):
     # if spp is unknown, then this is not sonnei, exit this function
     if spp_call == "Unknown":
         out_dict = {'genome':[genome_name], 'species':['not S. sonnei'], 'name':['NA'],'final genotype':['NA'],'confidence':['NA'],'lowest support for genotype marker':[''], 'poorly supported markers':[''], 'node support':[''], 'max support for additional markers':[''], 'additional markers':['']}
-        out_df = pd.DataFrame(out_dict, columns=['genome', 'final genotype', 'name', 'confidence', 'lowest support for genotype marker', 'poorly supported markers', 'node support', 'max support for additional markers', 'additional markers'])
+        out_df = pd.DataFrame(out_dict, columns=['genome', 'species', 'final genotype', 'name', 'confidence', 'lowest support for genotype marker', 'poorly supported markers', 'node support', 'max support for additional markers', 'additional markers'])
         return out_df, spp_call
     else:
         # if it is sonnei, then get the percentage
@@ -234,7 +234,7 @@ def extract_lineage_info(lineage_data, genome_name, lineage_name_dict):
         # if the percentage is <90, then exit this function as it's likely not sonnei
         if spp_percentage < 90:
             out_dict = {'genome':[genome_name], 'species':['not S. sonnei'], 'name':['NA'],'final genotype':['NA'],'confidence':['NA'],'lowest support for genotype marker':[''], 'poorly supported markers':[''], 'node support':[''], 'max support for additional markers':[''], 'additional markers':['']}
-            out_df = pd.DataFrame(out_dict, columns=['genome', 'final genotype', 'name', 'confidence', 'lowest supprot for genotype marker', 'poorly supported markers', 'node support', 'max support for additional markers', 'additional markers'])
+            out_df = pd.DataFrame(out_dict, columns=['genome', 'species', 'final genotype', 'name', 'confidence', 'lowest support for genotype marker', 'poorly supported markers', 'node support', 'max support for additional markers', 'additional markers'])
             return out_df, "Unknown"
 
     # if we are sonnei, then continue


### PR DESCRIPTION
Hello!

I came across a Python parsing error when running `parse_mykrobe_predict.py` on a S. Sonnei sample with less than 90% coverage.

The particular error was as follows:
```
final_results.to_csv(args.prefix + "_predictResults.tsv", index=False, sep="\t", columns=["genome", "species", "final genotype", "name", "confidence", "num QRDR", "parC_S80I", "gyrA_S83L", "gyrA_S83A", "gyrA_D87G", "gyrA_D87N", "gyrA_D87Y", "lowest support for genotype marker", "poorly supported markers", "max support for additional markers", "additional markers", "node support"])
... [more python traceback messages] ...
KeyError: "['species', 'lowest support for genotype marker'] not in index"
```
I was able to track this down to line 237: 
https://github.com/katholt/sonneityping/blob/b4ba875257b63f7544eeac037f921914ee238704/parse_mykrobe_predict.py#L237
where `'lowest support for genotype marker'` is misspelt as `'lowest supprot'`. In addition, `'species'` is not included as a column in the data frame which causes the second additional parsing error.

I also noticed that a similar parsing error would occur in line 229 since `'species'` is also not included as a column in the data frame:
https://github.com/katholt/sonneityping/blob/b4ba875257b63f7544eeac037f921914ee238704/parse_mykrobe_predict.py#L229

After making these small changes, I was able to prevent the Python parsing error. This will prevent script failure when the percent_coverage is under 90 and if `spp_call` is "Unknown". 

Thank you!